### PR TITLE
Added worker node creation

### DIFF
--- a/playbooks/scenario18a_cluster.yaml
+++ b/playbooks/scenario18a_cluster.yaml
@@ -3,6 +3,13 @@
   hosts: localhost
   vars:
     prefix: scenario18a-
+    test_cce_flavor: cce.s1.small
+    test_cce_container_network_mode: overlay_l2
+    test_node_flavor: s3.large.2
+    test_node_os: 'EulerOS 2.9'
+    test_volume_type: SAS
+    test_volume_size: 100
+
   tasks:
     - set_fact:
         prefix: "{{ (prefix + ( lookup('env', 'TASK_EXECUTOR_JOB_ID') | default(99999999 | random | to_uuid | hash('md5'), true) ) ) }}"
@@ -13,8 +20,8 @@
         test_network_name: "{{ (prefix + '-test_network_apimon') }}"
         # NOTE: CCE doesn't support "_"
         test_cluster_name: "{{ ('z-' + prefix + '-cluster') }}"
-        test_cce_flavor: "cce.s1.small"
-        test_cce_container_network_mode: "overlay_l2"
+        test_keypair_name: "{{ ( prefix + '-cce-kp' ) }}"
+        test_node_name: "{{ ( prefix + '-node' ) }}"
 
     - block:
 
@@ -26,6 +33,17 @@
           network_name: "{{ test_network_name }}"
           subnet_name: "{{ test_subnet_name }}"
           state: present
+
+      - name: Create Keypair
+        include_role:
+          name: opentelekomcloud.keypair
+        vars:
+          keypair_name: "{{ test_keypair_name }}"
+          state: "present"
+
+      - name: Get Availability zones
+        opentelekomcloud.cloud.availability_zone_info:
+        register: azs
 
       - name: Create CCE Cluster
         opentelekomcloud.cloud.cce_cluster:
@@ -41,6 +59,27 @@
           - 'service=cce'
           - 'metric=create_cce_cluster'
 
+      - name: Create Worker Node
+        opentelekomcloud.cloud.cce_cluster_node:
+          availability_zone: "{{ az }}"
+          cluster: "{{ test_cluster_name }}"
+          count: 1
+          data_volumes:
+            - volumetype: "{{ test_volume_type }}"
+              size: "{{ test_volume_size }}"
+          flavor: "{{ test_node_flavor }}"
+          ssh_key: "{{ test_keypair_name }}"
+          name: "{{ test_node_name }}"
+          network: "{{ test_network_name }}"
+          os: "{{ test_node_os }}"
+          root_volume_size: "{{ test_volume_size }}"
+          root_volume_type: "{{ test_volume_type }}"
+          wait: true
+          timeout: 300
+          state: present
+        vars:
+          az: "{{ azs['availability_zones'][0]['name'] }}"
+
       - name: Delete CCE Cluster
         opentelekomcloud.cloud.cce_cluster:
           name: "{{ test_cluster_name }}"
@@ -51,6 +90,13 @@
 
       always:
         - block:
+          - name: Create Keypair
+            include_role:
+              name: opentelekomcloud.keypair
+            vars:
+              keypair_name: "{{ test_keypair_name }}"
+              state: "absent"
+
           - name: Delete VPC
             include_role:
               name: opentelekomcloud.vpc


### PR DESCRIPTION
- Added worker node creation test. Simplified to basic parameters.

- Tested on prod eu-de, eu-nl, eu-ch2. 

- Currently AZ1 used for worker nodes. Random AZ will be deployed soon. 

- Avg time for completion the test - 13m28.661s